### PR TITLE
Implemented URL remapping strategies not dependent on user

### DIFF
--- a/riddle/game/level_clear.py
+++ b/riddle/game/level_clear.py
@@ -1,0 +1,20 @@
+"""This is a test level, still to be filled."""
+
+import random
+
+from jinja2 import Template
+from flask import session, request
+
+from riddle.utils import create_user, get_user
+from riddle.urls import add_route
+
+
+entry_text = '''<h1>Cleartext Level</h1>
+<h2>User {{user.name}} (id {{user.id}}), you accessed with {{passcode}}</h2>
+'''
+
+@add_route('/textclear', endpoint='testochiaro', defaults={'passcode': 'foobar'})
+@add_route('/cleartext/<passcode>', endpoint='cleartext')
+def entry(passcode):
+    user = get_user(session['user_id'])
+    return Template(entry_text).render(user=user, passcode=passcode), False

--- a/riddle/game/level_obfuscated.py
+++ b/riddle/game/level_obfuscated.py
@@ -1,0 +1,21 @@
+"""This is a test level, still to be filled."""
+
+import random
+
+from jinja2 import Template
+from flask import session, request
+
+from riddle.utils import create_user, get_user
+from riddle.urls import add_encoded_route
+
+
+entry_text = '''<h1>Obfuscated Level</h1>
+<h2>User {{user.name}} (id {{user.id}}), you accessed with {{passcode}}</h2>
+'''
+
+
+# Obfuscate level name by inverting the order of its name
+@add_encoded_route('/{name}/<passcode>', lambda x: x[::-1])
+def entry(passcode):
+    user = get_user(session['user_id'])
+    return Template(entry_text).render(user=user, passcode=passcode), False

--- a/riddle/urls.py
+++ b/riddle/urls.py
@@ -1,0 +1,27 @@
+import functools
+
+
+def add_route(route, **options):
+    """Use flask's routing mechanism."""
+    def _deco(entry):
+        # Append to the list if existing, else create the list
+        if hasattr(entry, 'route'):
+            entry.route.append((route, options))
+        else:
+            entry.route = [(route, options)]
+        return entry
+    return _deco
+
+
+def add_encoded_route(route, encoder, **options):
+    """Encoder is a function that given a string encodes it."""
+    def _deco(entry):
+        def _builder(name):
+            """Encode name and replace it in route."""
+            return route.format(name=encoder(name))
+        if hasattr(entry, 'route'):
+            entry.route.append((_builder, options))
+        else:
+            entry.route = [(_builder, options)]
+        return entry
+    return _deco

--- a/riddle/utils.py
+++ b/riddle/utils.py
@@ -1,7 +1,7 @@
 import os
 import sqlite3
-from riddle import database
 from pathlib import Path
+from riddle import database
 from riddle.names import random_animal, generate_random_animal
 
 
@@ -58,6 +58,15 @@ def get_level_structure():
     root, files = get_level_files()
     return [str((fp.parent / fp.stem).relative_to(root))
             for fp in files]
+
+
+def get_level_route(name, entry_point):
+    """Given the path of the level and the entry_point, return its route."""
+    if hasattr(entry_point, 'route'):
+        # Call routes that are callable
+        return [(r(name) if callable(r) else r, d)
+                for r, d in entry_point.route]
+    return [(f'/{name}', {})]  # Default route for undecorated entry points
 
 
 def level_structure_dict():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,76 +2,61 @@ from pathlib import Path
 from unittest import mock
 from riddle.utils import (get_level_structure, get_level_files,
     is_user_allowed, strip_common_parents, level_structure_dict,
-    level_prerequisites)
+    level_prerequisites, get_level_route)
+
+
+example_levels = [
+    'riddle_1_a',
+    'riddle_1_b',
+    'level_2_a/riddle_2_a',
+    'level_2_a/riddle_2_b',
+    'level_2_a/level_3_a/riddle_3',
+    'level_2_a/level_3_b/riddle_3_a',
+    'level_2_a/level_3_b/riddle_3_b',
+    'level_2_a/level_3_b/riddle_3_c',
+    'level_2_b/riddle_2',
+]
+
+
+example_levels_2 = [
+    'riddle_1',
+    'riddle_2',
+    'level_1/riddle',
+    'level_2/riddle_1',
+    'level_2/riddle_2',
+    'level_2/riddle_3',
+    'level_2/level_3/riddle_1',
+    'level_2/level_3/riddle_2',
+]
+
+example_entry_points = [
+    'foo'
+]
 
 
 def test_level_files():
+    file_list = [Path('riddle/game') / f'{l}.py' for l in example_levels]
+
     with mock.patch('pathlib.Path.glob') as mockglob:
-        mockglob.return_value = [
-            Path('riddle/game/riddle_1_a.py'),
-            Path('riddle/game/riddle_1_b.py'),
-            Path('riddle/game/level_2_a/riddle_2_a.py'),
-            Path('riddle/game/level_2_a/riddle_2_b.py'),
-            Path('riddle/game/level_2_a/level_3_a/riddle_3.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_a.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_b.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_c.py'),
-            Path('riddle/game/level_2_b/riddle_2.py'),
-        ]
+        mockglob.return_value = file_list
         root, ls = get_level_files()
-        assert ls == [
-            Path('riddle/game/riddle_1_a.py'),
-            Path('riddle/game/riddle_1_b.py'),
-            Path('riddle/game/level_2_a/riddle_2_a.py'),
-            Path('riddle/game/level_2_a/riddle_2_b.py'),
-            Path('riddle/game/level_2_a/level_3_a/riddle_3.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_a.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_b.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_c.py'),
-            Path('riddle/game/level_2_b/riddle_2.py'),
-        ]
+        assert ls == file_list
 
 
 def test_level_structure():
+    file_list = [Path('riddle/game') / f'{l}.py' for l in example_levels]
+
     with mock.patch('riddle.utils.get_level_files') as mockglob:
-        mockglob.return_value = Path('riddle/game/'), [
-            Path('riddle/game/riddle_1_a.py'),
-            Path('riddle/game/riddle_1_b.py'),
-            Path('riddle/game/level_2_a/riddle_2_a.py'),
-            Path('riddle/game/level_2_a/riddle_2_b.py'),
-            Path('riddle/game/level_2_a/level_3_a/riddle_3.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_a.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_b.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_c.py'),
-            Path('riddle/game/level_2_b/riddle_2.py'),
-        ]
+        mockglob.return_value = Path('riddle/game/'), file_list
         ls = get_level_structure()
-        assert ls == [
-            'riddle_1_a',
-            'riddle_1_b',
-            'level_2_a/riddle_2_a',
-            'level_2_a/riddle_2_b',
-            'level_2_a/level_3_a/riddle_3',
-            'level_2_a/level_3_b/riddle_3_a',
-            'level_2_a/level_3_b/riddle_3_b',
-            'level_2_a/level_3_b/riddle_3_c',
-            'level_2_b/riddle_2',
-        ]
+        assert ls == example_levels
 
 
 def test_level_structure_dict():
+    file_list = [Path('riddle/game') / f'{l}.py' for l in example_levels]
+
     with mock.patch('riddle.utils.get_level_files') as mockglob:
-        mockglob.return_value = Path('riddle/game/'), [
-            Path('riddle/game/riddle_1_a.py'),
-            Path('riddle/game/riddle_1_b.py'),
-            Path('riddle/game/level_2_a/riddle_2_a.py'),
-            Path('riddle/game/level_2_a/riddle_2_b.py'),
-            Path('riddle/game/level_2_a/level_3_a/riddle_3.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_a.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_b.py'),
-            Path('riddle/game/level_2_a/level_3_b/riddle_3_c.py'),
-            Path('riddle/game/level_2_b/riddle_2.py'),
-        ]
+        mockglob.return_value = Path('riddle/game/'), file_list
         ls = level_structure_dict()
         assert ls == {
             'riddle_1_a': None,
@@ -111,16 +96,7 @@ def test_strip_common_parents():
 
 def test_level_prerequisites():
     with mock.patch('riddle.utils.get_level_structure') as mockls:
-        mockls.return_value = [
-            'riddle_1',
-            'riddle_2',
-            'level_1/riddle',
-            'level_2/riddle_1',
-            'level_2/riddle_2',
-            'level_2/riddle_3',
-            'level_2/level_3/riddle_1',
-            'level_2/level_3/riddle_2',
-        ]
+        mockls.return_value = example_levels_2
 
         cases = [
             ['riddle_1', []],
@@ -159,20 +135,10 @@ def test_user_access():
             ['level/riddle', ['riddle', 'level/riddle'], True],
         ]
         for level, solved, expected in cases:
-            print("TESTING CASE", level, solved, expected)
             assert is_user_allowed(level, solved) == expected
 
     with mock.patch('riddle.utils.get_level_structure') as mockls:
-        mockls.return_value = [
-            'riddle_1',
-            'riddle_2',
-            'level_1/riddle',
-            'level_2/riddle_1',
-            'level_2/riddle_2',
-            'level_2/riddle_3',
-            'level_2/level_3/riddle_1',
-            'level_2/level_3/riddle_2',
-        ]
+        mockls.return_value = example_levels_2
 
         cases = [
             ['riddle_1', [], True],
@@ -209,5 +175,9 @@ def test_user_access():
         ]
 
         for level, solved, expected in cases:
-            print("TESTING CASE", level, solved, expected)
             assert is_user_allowed(level, solved) == expected
+
+
+def test_level_routing():
+    for l in example_levels:
+        assert get_level_route(l, lambda: 'foo') == '/' + l


### PR DESCRIPTION
This is a step in resolving #3, introducing a couple of decorators to define and garble level URLs. This does not introduce a way to have user-dependent level URLs, but allows to obfuscate the level name once and parametrize it to have user-dependent obfuscated parameters.

This also fixes a bug about starting a new user session.